### PR TITLE
bottle-unneeded 2020.09.20 (new formula)

### DIFF
--- a/Formula/dev-bottle-unneeded.rb
+++ b/Formula/dev-bottle-unneeded.rb
@@ -1,0 +1,32 @@
+class DevBottleUnneeded < Formula
+  desc "Youtube-dl: Download YouTube videos from the command-line"
+  homepage "https://ytdl-org.github.io/youtube-dl/"
+  url "https://github.com/ytdl-org/youtube-dl/releases/download/2020.09.20/youtube-dl-2020.09.20.tar.gz"
+  sha256 "ac1a799cf968345bf29089ed2e5c5d4f4a32031625d808369e61b6362d1c7cde"
+  license "Unlicense"
+
+  head do
+    url "https://github.com/ytdl-org/youtube-dl.git"
+    depends_on "pandoc" => :build
+  end
+
+  bottle :unneeded
+
+  conflicts_with "youtube-dl", because: "both install a `youtube-dl` binary"
+
+  def install
+    system "make", "PREFIX=#{prefix}" if build.head?
+    bin.install "youtube-dl"
+    man1.install "youtube-dl.1"
+    bash_completion.install "youtube-dl.bash-completion"
+    zsh_completion.install "youtube-dl.zsh" => "_youtube-dl"
+    fish_completion.install "youtube-dl.fish"
+  end
+
+  test do
+    # commit history of homebrew-core repo
+    system "#{bin}/youtube-dl", "--simulate", "https://www.youtube.com/watch?v=pOtd1cbOP7k"
+    # homebrew playlist
+    system "#{bin}/youtube-dl", "--simulate", "--yes-playlist", "https://www.youtube.com/watch?v=pOtd1cbOP7k&list=PLMsZ739TZDoLj9u_nob8jBKSC-mZb0Nhj"
+  end
+end


### PR DESCRIPTION
Add `dev-bottle-unneeded` formula

This is a duplicate of the `youtube-dl` formula
