### PR TITLE
Formulae: depend on python@3.9

### DIFF
--- a/Formula/dev-bottle-unneeded.rb
+++ b/Formula/dev-bottle-unneeded.rb
@@ -14,6 +14,8 @@ class DevBottleUnneeded < Formula
 
   conflicts_with "youtube-dl", because: "both install a `youtube-dl` binary"
 
+  depends_on "ruby"
+
   def install
     system "make", "PREFIX=#{prefix}" if build.head?
     bin.install "youtube-dl"

--- a/Formula/dev-bottle.rb
+++ b/Formula/dev-bottle.rb
@@ -13,6 +13,8 @@ class DevBottle < Formula
 
   conflicts_with "aescrypt", because: "both install `aescrypt` and `aesget` binaries"
 
+  depends_on "ruby"
+
   def install
     system "./configure"
     system "make"


### PR DESCRIPTION
This commit adds a python@3.9 dependency to both formulae in this tap.
This is intentionally a "bad commit" and I have created it with a label
using `gh` from the command line.
