### PR TITLE
check: add `brew` prefix to failed commands

### DIFF
--- a/lib/check.rb
+++ b/lib/check.rb
@@ -41,7 +41,7 @@ module Check
     puts <<~MESSAGE
       #{Formatter.headline("Failure!", color: :red)}
       The following #{"command".pluralize failures.count} failed:
-        #{formatted_failures.join("\n  ")}
+        #{formatted_failures.map { |cmd| "brew #{cmd}" }.join("\n  ")}
     MESSAGE
   end
 end


### PR DESCRIPTION
Before:

```console
==> Failure!
The following command failed:
 typecheck
```

After:

```console
==> Failure!
The following command failed:
  brew typecheck
```